### PR TITLE
add lab 060 for testing the model manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 3. [Daten und Modell versionieren](labs/030_lab_data_versioning.md)
 4. [Metriken und Experimente](labs/040_lab_metrics.md)
 5. [GitHub Actions](labs/050_lab_github_actions.md)
+6. [Modell manuell testen](labs/060_lab_deploy_model.md)
 
 ### Weitere Labs
 

--- a/labs/050_lab_github_actions.md
+++ b/labs/050_lab_github_actions.md
@@ -162,4 +162,5 @@ Darum erstellen wir ein weiteres Experiment:
 
 ---
 
-[← Metriken und Experimente](040_lab_metrics.md) | [STARTSEITE →](../README.md)
+[← Metriken und Experimente](040_lab_metrics.md) | [STARTSEITE](../README.md) |
+[Modell manuell testen →](060_lab_deploy_model.md)

--- a/labs/060_lab_deploy_model.md
+++ b/labs/060_lab_deploy_model.md
@@ -1,0 +1,33 @@
+# Modell manuell testen
+
+Um das Modell auch einmal manuell testen zu können, erstellen wir eine kleine Applikation.
+
+## Abhängigkeiten installieren
+
+1. In der Datei `requirements.txt` folgendes hinzufügen und speichern:
+    ```diff
+    gradio==3.48.0
+    scikit-image==0.22.0
+    ```
+2. Danach die Abhängigkeiten installieren.
+    ```shell
+    pip install -r requirements.txt
+    ```
+
+## Applikation erstellen und starten
+
+1. Die Datei `src/app.py` erstellen und den Code aus https://github.com/iimsand/mlops-techlab-digits-template/blob/solution/060_lab_deploy_model/src/app.py kopieren.
+1. Die Datei speichern.
+1. Applikation starten mit:
+    ```shell
+    python src/app.py
+    ```
+1. Es dauert nun ein paar Sekunden, bis eine Meldung mit einer öffentlichen URL erscheint die mit `gradio.live` endet (**ACHTUNG**: es erscheint auch eine lokale URL, diese kann aber mit Codespaces nicht genutzt werden!):
+    ```
+    Running on public URL: https://<ZEICHENFOLGE>.gradio.live
+    ```
+1. Die URL kopieren und in einem Browser öffnen.
+
+---
+
+[← GitHub Actions](050_lab_github_actions.md) | [STARTSEITE →](../README.md)


### PR DESCRIPTION
Ein weiteres Lab, dass dem Teilnehmer ermöglicht, das Modell selbständig und manuell mit einer einfachen Web-Applikation zu testen.
Dies funktioniert auch mit Codespaces, da die Applikation über eine öffentliche URL zur Verfügung gestellt wird (wird generiert).