### PR TITLE
Updates for Cloud Native Zurich - Juni 2025

### DIFF
--- a/labs/020_lab_init_pipeline.md
+++ b/labs/020_lab_init_pipeline.md
@@ -4,10 +4,10 @@
 
 1. Falls dvc noch nicht im `requirements.txt` eingetragen ist, diese Zeile hinzufügen (ohne das `+` am Anfang):
     ```diff
-    scikit-learn==1.3.0
+    scikit-learn==1.3.2
     matplotlib==3.7.2
     pandas==2.0.3
-    +dvc==3.42.0
+    +dvc==3.59.2
     jupyterlab==4.0.3
     ```
 1. Die neue Abhängigkeit installieren mit folgendem Befehl 

--- a/labs/050_lab_github_actions.md
+++ b/labs/050_lab_github_actions.md
@@ -28,7 +28,7 @@ on:
       - ".github/workflows/cml.yaml"
 jobs:
   train-and-report:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/labs/500_self_hosted_runner.md
+++ b/labs/500_self_hosted_runner.md
@@ -52,7 +52,7 @@ Dies ist ersichtlich am Badge neben dem Repository Titel wenn man https://github
     ...
     jobs:
       train-and-report:
-    -   runs-on: ubuntu-20.04
+    -   runs-on: ubuntu-22.04
     +   runs-on: [self-hosted, cml]
         steps:
         ...

--- a/labs/510_s3_bucket_with_minio.md
+++ b/labs/510_s3_bucket_with_minio.md
@@ -3,8 +3,8 @@
 1. Die Datei `requirements.txt` anpassen:
     ```diff
     ...
-    -dvc==3.15.0
-    +dvc[s3]==3.15.0
+    -dvc==3.59.2
+    +dvc[s3]==3.59.2
     ...
     ```
 1. Abhängigkeiten installieren (zuerst prüfen das man sich im virtuellen Environment befindet, ansonsten mit `source .env/bin/activate` aktivieren):


### PR DESCRIPTION
- Ubuntu 20.04 runner for GitHub Actions is deprecated, needs 22.04
- Upgrade scikit-learn and dvc because of Python 3.10 which is preinstalled in Ubuntu 22.04
- 